### PR TITLE
clone process.argv so we don't clobber it

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -144,18 +144,20 @@ cli.disable = function (/*plugins*/) {
  * @param {Boolean} keep_arg0 (optional - default is false)
  * @api public
  */
-cli.setArgv = function (arr, keep_arg0) {
-    if (!(arr instanceof Array)) {
-        arr = arr.split(' ');
+cli.setArgv = function (argv, keep_arg0) {
+    if (typeof argv == 'string') {
+      argv = argv.split(' ');
+    } else {
+      argv = argv.slice();
     }
-    cli.app = arr.shift();
+    cli.app = argv.shift();
     //Strip off argv[0] if it's 'node'
     if (!keep_arg0 && 'node' === path.basename(cli.app)) {
-        cli.app = arr.shift();
+        cli.app = argv.shift();
     }
     cli.app = cli.native.path.basename(cli.app);
     argv_parsed = false;
-    cli.args = cli.argv = argv = arr;
+    cli.args = cli.argv = argv;
     cli.argc = argv.length;
 };
 cli.setArgv(process.argv);


### PR DESCRIPTION
One of the modules I'm using needs access to the full, untouched process.argv, and since there's no reason to clobber it unnecessarily, I think the best policy is to clone first so shift() doesn't remove items from the original.
