### PR TITLE
some programs, like nodelint, emit data to stdout even when failing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1067,7 +1067,7 @@ cli.exec = function (cmd, callback, errback) {
         err = err || stderr;
         if (err) {
             if (errback) {
-                return errback(err);
+                return errback(err, stdout);
             }
             return cli.fatal('exec() failed\n' + err);
         }


### PR DESCRIPTION
without this I have no access to the data I need from nodelint when cli.exec'ing it
