### PR TITLE
Allow opt value to start with a hyphen (-)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -722,7 +722,7 @@ cli.getValue = function (default_val, validate_func, err_msg) {
 
         //If there's no args left or the next arg is an opt, return the
         //default value (if specified) - otherwise fail
-        if (!argv.length || argv[0][0] === '-') {
+        if (!argv.length || (argv[0].length === 1 && argv[0][0] === '-')) {
             throw 'No value';
         }
 


### PR DESCRIPTION
This allows for the following:

```
--time -30 --foo bar
```

While still producing an error on:

```
--time - --foo bar
```
