### PR TITLE
Adds optional decimal parameter to progress

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1086,8 +1086,9 @@ cli.exec = function (cmd, callback, errback) {
  * @api public
  */
 var last_progress_call, progress_len = 74;
-cli.progress = function (progress) {
+cli.progress = function (progress, decimals) {
     if (progress < 0 || progress > 1 || isNaN(progress)) return;
+    if (!decimals) decimals = 0;
     var now = (new Date()).getTime();
     if (last_progress_call && (now - last_progress_call) < 100 && progress !== 1) {
         return; //Throttle progress calls
@@ -1103,7 +1104,12 @@ cli.progress = function (progress) {
     for (var i = 1; i <= progress_len; i++) {
         str += i <= barLength ? '#' : ' ';
     }
-    cli.native.util.print('[' + str + '] ' +  Math.floor(progress * 100) + '%' + (progress === 1 ? '\n' : '\u000D'));
+    var pwr = Math.pow(10, decimals);
+    var percentage = Math.floor(progress * 100 * pwr) / pwr + '%';
+    for (i = 0; i < decimals; i++) {
+        percentage += ' ';
+    }
+    cli.native.util.print('[' + str + '] ' +  percentage + (progress === 1 ? '\n' : '\u000D'));
 };
 
 /**


### PR DESCRIPTION
This pull request adds an optional parameter to the progress function, enabling the option to set a customized number of decimals for the percentage number.
