### PR TITLE
Fixed the problem with nodejs naming on systems with nodejs binary name

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -143,7 +143,7 @@ cli.setArgv = function (arr, keep_arg0) {
     }
     cli.app = arr.shift();
     //Strip off argv[0] if it's a node binary
-    if (!keep_arg0 && ('node' === cli.native.path.basename(cli.app)
+    if (!keep_arg0 && (process.execPath === cli.native.path.basename(cli.app)
             || process.execPath === cli.app)) {
         cli.app = arr.shift();
     }


### PR DESCRIPTION
On Ubuntu the node binary is called nodejs, when installed from packages. This causes wrong argument to be deleted from the list. This fixes it by reliably comparing execPath to both basename and full path of the cli.app.
