### PR TITLE
Modified fix for stderr not draining on Windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -340,7 +340,8 @@ cli.parse = function (opts, command_def) {
                     cli.parsePackageJson();
                 }
                 console.error(cli.app + ' v' + cli.version);
-                return cli.exit();
+                cli.exit();
+                break;
             } else if (enable.daemon && (o === 'd' || o === 'daemon')) {
                 daemon_arg = cli.getArrayValue(['start','stop','restart','pid','log'], is_long ? null : 'start');
                 continue;


### PR DESCRIPTION
Breaking the loop works while the original return call does not. Not sure why, but my decidedly unscientific tests appear to indicate Windows is happy with the change.
