### PR TITLE
Fix argv[0] node binary removal in Windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -146,7 +146,7 @@ cli.setArgv = function (arr, keep_arg0) {
     // So this is still broken and will break if you are calling node through a
     // symlink, unless you are lucky enough to have it as 'node' literal. Latter
     // is a hack, but resolving abspaths/symlinks is an unportable can of worms.
-    if (!keep_arg0 && ('node' === cli.native.path.basename(cli.app)
+    if (!keep_arg0 && (['node', 'node.exe'].indexOf(cli.native.path.basename(cli.app)) !== -1
             || cli.native.path.basename(process.execPath) === cli.app
             || process.execPath === cli.app)) {
         cli.app = arr.shift();


### PR DESCRIPTION
In Windows, the node binary's basename is `node.exe`.

This also fixes the issue I've been having with JSHint: https://github.com/jshint/jshint/issues/1905
