### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,5 @@
     { "name": "Douglas Meyer", "github": "https://github.com/DouglasMeyer" }
   ],
   "engines": { "node": ">=0.2.5" },
-  "licenses": [{
-    "type": "MIT"
-  }]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/