### PR TITLE
Fix spinner compatibility with file i/o

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1135,6 +1135,10 @@ cli.progress = function (progress, decimals, stream) {
 var spinnerInterval;
 cli.spinner = function (prefix, end, stream) {
     stream = stream || process.stdout;
+    if(!stream.clearLine) {
+        stream.write(prefix + '\n');
+        return;
+    }
     if (end) {
         stream.clearLine();
         stream.cursorTo(0);


### PR DESCRIPTION
Attempting to resolve #67. Spinner will still output messages but will not try to animate.