### PR TITLE
corrected semi-colon to colon in illegal file characters

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -824,7 +824,7 @@ cli.getIp = function (default_val) {
 cli.getPath = function (default_val, identifier) {
     identifier = identifier || 'path';
     return cli.getValue(default_val, function (value) {
-        if (value.match(/[?*;{}]/)) {
+        if (value.match(/[?*:{}]/)) {
             throw 'Invalid path';
         }
         return value;


### PR DESCRIPTION
Semi-colon is a legal character in all operating systems, though colon is not. I'm guessing this is just a typo. Verified both cases by tweaking one of the examples.
