### PR TITLE
Clean up README for argument types

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,27 +61,27 @@ cli.parse({
 	Below is a list of the return types followed by a description and a list of  
 	valid values you can use for this option to get desired type of Object back.
 	- **as-is:** What you enter, is what you get
-          - 'string', 1,  true
-   - **int:** Is converted to an Integer wrapped in a Number Object
-          - 'int', 'number', 'num',
-          - 'time', 'seconds', 'secs', 'minutes', 'mins'
-          - 'x', 'n'
-   - **date:** Is converted to a Date Object
-          - 'date', 'datetime', 'date_time'
+        - 'string', 1,  true
+    - **int:** Is converted to an Integer wrapped in a Number Object
+        - 'int', 'number', 'num',
+        - 'time', 'seconds', 'secs', 'minutes', 'mins'
+        - 'x', 'n'
+    - **date:** Is converted to a Date Object
+        - 'date', 'datetime', 'date_time'
 	- **float:** Is converted to a Float wrapped in a Number Object
-          - 'float', 'decimal'
+        - 'float', 'decimal'
 	- **file:** Is converted to a String Object if it is a valid path
-          - 'path', 'file', 'directory', 'dir'
+        - 'path', 'file', 'directory', 'dir'
 	- **email:** Converted to a String Object if it is a valid email format
-          - 'email'
+        - 'email'
 	- **url:** Converted to a String Object if it is a valid URL format
-          - 'url', 'uri', 'domain', 'host'
-   - **ip:** Converted to a String Object if it is a valid IP Address format
-          - 'ip'
-   - **true:** Converted to true if argument is present on command line
-          - 'bool', 'boolean', 'on'
+        - 'url', 'uri', 'domain', 'host'
+    - **ip:** Converted to a String Object if it is a valid IP Address format
+        - 'ip'
+    - **true:** Converted to true if argument is present on command line
+        - 'bool', 'boolean', 'on'
 	- **false:** Converted to false if argument is present on command line
-          - 'false', 'off', false, 0
+        - 'false', 'off', false, 0
 4.	A default value for this option if one is not given on the command line
 
 ## Helper methods


### PR DESCRIPTION
Noticed that the formatting was weird on npmjs.org and on github. Just fixed a bit of spacing so it displays correctly. Indented with 4 spaces.