### PR TITLE
add link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn link && yarn link cli && yarn install && cd examples && node progress"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![run on repl.it](http://repl.it/badge/github/node-js-libs/cli)](https://repl.it/github/node-js-libs/cli)
+
 **cli is a toolkit for rapidly building command line apps - it includes:**
 
 - Full featured opts/args parser


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-cli):

![image](https://i.imgur.com/FEPMmcP.png)
